### PR TITLE
Fix syntax error in GitHub Actions workflow by adding missing 'fi' st…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
             git push
           else
             echo "No changes to publish."
-
+          fi


### PR DESCRIPTION
…atement to properly close the conditional block.