### PR TITLE
Update GitHub Actions workflow to use pull_request_target event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish Workshop Pages
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
This commit modifies the publish.yml workflow file to change the event trigger from pull_request to pull_request_target, ensuring that the workflow runs with the permissions of the base repository, which enhances security and access control during the workflow execution.

Workflow permission are the absolute worst. UGH